### PR TITLE
executeQuery to return an array of records

### DIFF
--- a/couchbase.android.ts
+++ b/couchbase.android.ts
@@ -77,10 +77,10 @@ export class Couchbase {
     executeQuery(viewName: string) {
         var query = this.database.getView(viewName).createQuery();
         var result = query.run();
-        var parsedResult: Object = {};
-        while (result.hasNext()) {
+        var parsedResult: Array<any> = [];
+        while(result.hasNext()) {
             var row = result.next();
-            parsedResult[row.getKey()] = row.getValue();
+            parsedResult.push(JSON.parse(row.getValue()));
         }
         return parsedResult;
     }


### PR DESCRIPTION
This change is necessary to make it consistent with the result returned from couchbase.ios.ts (which returns an array of object, not an Object with attributes for each record).
Also it makes more sense for the result to be a set of already parsed records.