### PR TITLE
Fix webpack module error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "nativescript-couchbase",
   "version": "1.0.16",
   "description": "Couchbase Lite plugin for Telerik NativeScript",
-  "main": "couchbase.js",
+  "main": "couchbase",
+  "typings": "couchbase.d.ts",
   "nativescript": {
     "platforms": {
       "android": "2.0.0",


### PR DESCRIPTION
Resolve issues with webpack error:
```
Module not found: Error: Can't resolve 'nativescript-couchbase'
```

Would be nice to really great a new version soon, as this issue is a real big problem for us